### PR TITLE
Update c_cpp_properties.json "goto definition" for allwpilib

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,8 @@
             "name": "Linux",
             "includePath": [
                 "${workspaceFolder}/vendordeps/sdk/linux64/include/luajit-2.1/**",
-                "${workspaceFolder}/src/**"
+                "${workspaceFolder}/src/**",
+                "${workspaceRoot}/../allwpilib"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/clang",
@@ -18,7 +19,8 @@
             "name": "Win32",
             "includePath": [
                 "${workspaceFolder}/vendordeps/sdk/msvc/include/luajit-2.1/**",
-                "${workspaceFolder}/src/**"
+                "${workspaceFolder}/src/**",
+                "${workspaceRoot}/../allwpilib"
             ],
             "defines": [
                 "_DEBUG",


### PR DESCRIPTION
This change allows vscode to "goto definition" for allwpilib if its checked out.

If you cd up a dir and check out wpilibsute 
```
cd ..
git clone https://github.com/wpilibsuite/allwpilib.git
```

<img width="1330" alt="Screenshot 2024-04-05 at 1 33 11 AM" src="https://github.com/horner/bot-2024/assets/6094599/08bdbb8b-cc0c-4ae3-bab9-138faf85c6a5">
