### PR TITLE
build.gradle: loosen match for macos platform detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ String sdkSlugForTargetName (String name) {
         return "roborio"
     } else if (lname.contains ("windowsx86-64")) {
         return "msvc"
-    } else if (lname.contains ("darwin")) {
+    } else if (lname.contains ("darwin") || lname.contains('osx')) {
         return "macos"
     }
 


### PR DESCRIPTION
resolves gradle not being able to find lua.h on mac os

@martincarapia - I did this edit in the github editor as this machine doesn't have ssh setup right now.  make sure to check this; it should find the header OK, but still fail on the link phase due to the Universal binary problem discussed in discord.